### PR TITLE
Add Citi Bike widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@
 
 ## Traveling
 
-- [location-location-location](https://github.com/doersino/scriptable-widgets/tree/main/location-location-location) - Show Google Maps image from current location.
-
 - [citi_bike.js](https://gist.github.com/coughski/43c7a4da3829a3ffe394d6eeb6a8c90a) - A station status tracker showing bike availability for NYC's Citi Bike bicycle sharing program.
 
 <img src="https://user-images.githubusercontent.com/945761/161787518-9cbd252c-64f4-4c77-9793-a4b3d3c3f1ef.jpg" width="400"/>
+
+- [location-location-location](https://github.com/doersino/scriptable-widgets/tree/main/location-location-location) - Show Google Maps image from current location.
 
 ## Related
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@
 
 - [location-location-location](https://github.com/doersino/scriptable-widgets/tree/main/location-location-location) - Show Google Maps image from current location.
 
+- [citi_bike.js](https://gist.github.com/coughski/43c7a4da3829a3ffe394d6eeb6a8c90a) - A station status tracker showing bike availability for NYC's Citi Bike bicycle sharing program.
+
+<img src="https://user-images.githubusercontent.com/945761/161787518-9cbd252c-64f4-4c77-9793-a4b3d3c3f1ef.jpg" width="400"/>
+
 ## Related
 
 ### Download helper


### PR DESCRIPTION
A station status tracker showing bike availability for NYC's Citi Bike bicycle sharing program.
[https://gist.github.com/coughski/43c7a4da3829a3ffe394d6eeb6a8c90a](https://gist.github.com/coughski/43c7a4da3829a3ffe394d6eeb6a8c90a)