### PR TITLE
Add nfl-team-schedule-widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@
 
 - [fitx-widget.js](https://gist.github.com/DanielStefanK/487175b6f65ede401e37ee4848970176) - Workload of a FitX gym.
 
+- [nfl-team-schedule-widget](https://github.com/brianwalborn/nfl-team-schedule-widget) - The current season schedule for an NFL team.
+
 - [rsg_group_mcfit_high5_johnreed_capacity_widget.js](https://gist.github.com/masselmello/6d4f4c533b98b2550ee23a7a5e6c6cff) - Capacity of the nearest McFit gym.
 
 - [skiable](https://github.com/p0fi/skiable-for-scriptable) - Skiing information like snow height or the number of open lifts. 


### PR DESCRIPTION
Project URL: https://github.com/brianwalborn/nfl-team-schedule-widget
Useful widget to display any NFL team's schedule for the current year.