### PR TITLE
Added widget for lichess statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,12 @@
 - [fitx-widget.js](https://gist.github.com/DanielStefanK/487175b6f65ede401e37ee4848970176) - Workload of a FitX gym.
 
 - [nfl-team-schedule-widget](https://github.com/brianwalborn/nfl-team-schedule-widget) - The current season schedule for an NFL team.
-  
-- [lichess Widget](https://github.com/bestmacfly/Scriptable-lichess-Widget) - Your current lichess statistics.
-
-  <img src="https://github.com/bestmacfly/Scriptable-lichess-Widget/raw/main/Screenshot.png " width="400"/>
 
 - [rsg_group_mcfit_high5_johnreed_capacity_widget.js](https://gist.github.com/masselmello/6d4f4c533b98b2550ee23a7a5e6c6cff) - Capacity of the nearest McFit gym.
+  
+- [Scriptable-lichess-Widget](https://github.com/bestmacfly/Scriptable-lichess-Widget) - Your current lichess statistics.
+
+  <img src="https://raw.githubusercontent.com/bestmacfly/Scriptable-lichess-Widget/main/Screenshot.png" width="400"/>
 
 - [skiable](https://github.com/p0fi/skiable-for-scriptable) - Skiing information like snow height or the number of open lifts. 
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@
   
 - [lichess Widget](https://github.com/bestmacfly/Scriptable-lichess-Widget) - Your current lichess statistics.
 
+  <img src="https://github.com/bestmacfly/Scriptable-lichess-Widget/Screenshot.png " width="400"/>
+
 - [rsg_group_mcfit_high5_johnreed_capacity_widget.js](https://gist.github.com/masselmello/6d4f4c533b98b2550ee23a7a5e6c6cff) - Capacity of the nearest McFit gym.
 
 - [skiable](https://github.com/p0fi/skiable-for-scriptable) - Skiing information like snow height or the number of open lifts. 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
   
 - [lichess Widget](https://github.com/bestmacfly/Scriptable-lichess-Widget) - Your current lichess statistics.
 
-  <img src="https://github.com/bestmacfly/Scriptable-lichess-Widget/Screenshot.png " width="400"/>
+  <img src="https://github.com/bestmacfly/Scriptable-lichess-Widget/raw/main/Screenshot.png " width="400"/>
 
 - [rsg_group_mcfit_high5_johnreed_capacity_widget.js](https://gist.github.com/masselmello/6d4f4c533b98b2550ee23a7a5e6c6cff) - Capacity of the nearest McFit gym.
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@
 - [fitx-widget.js](https://gist.github.com/DanielStefanK/487175b6f65ede401e37ee4848970176) - Workload of a FitX gym.
 
 - [nfl-team-schedule-widget](https://github.com/brianwalborn/nfl-team-schedule-widget) - The current season schedule for an NFL team.
+  
+- [lichess Widget](https://github.com/bestmacfly/Scriptable-lichess-Widget) - Your current lichess statistics.
 
 - [rsg_group_mcfit_high5_johnreed_capacity_widget.js](https://gist.github.com/masselmello/6d4f4c533b98b2550ee23a7a5e6c6cff) - Capacity of the nearest McFit gym.
 


### PR DESCRIPTION
I have implemented a useful widget to show your current statistics from lichess (a popular open source chess platform). It seems to be the first widget for this use case.
Link to my package: https://github.com/bestmacfly/Scriptable-lichess-Widget