### PR TITLE
Add scriptable-live-tennis to Sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@
 
   <img src="https://raw.githubusercontent.com/bestmacfly/Scriptable-lichess-Widget/main/Screenshot.png" width="400"/>
 
+- [scriptable-live-tennis](https://github.com/livetennisapi/scriptable-live-tennis) - Live tennis scores with serving and break-point indicators.
+
 - [skiable](https://github.com/p0fi/skiable-for-scriptable) - Skiing information like snow height or the number of open lifts. 
 
   <img src="https://raw.githubusercontent.com/p0fi/skiable-for-scriptable/main/cover.png" width="400"/>


### PR DESCRIPTION
Adds [scriptable-live-tennis](https://github.com/livetennisapi/scriptable-live-tennis) to the Sports section (alphabetical, one suggestion per the guidelines).

Why it belongs: it would be the first tennis entry in Sports (which currently covers college football, NFL, gyms, chess and skiing). The widget shows live match scores — players with rankings, sets/games/points, who is serving, and a derived break-point marker — at widget-refresh cadence (refreshAfterDate >= 15 min, with response caching so it fits the API's free tier), with an upcoming-fixtures fallback when nothing is live and graceful in-widget no-key/error states. MIT licensed, small/medium/large layouts, CI-checked.

Disclosure: I maintain the API it uses (Live Tennis API).